### PR TITLE
Story: [CCLS 1927] Allow complete document to be uploaded via post endpoint

### DIFF
--- a/soa-gateway-api/open-api-specification.yml
+++ b/soa-gateway-api/open-api-specification.yml
@@ -606,7 +606,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/baseDocument"
+              $ref: "#/components/schemas/document"
       parameters:
         - $ref: '#/components/parameters/soaGatewayUserLoginId'
         - $ref: '#/components/parameters/soaGatewayUserRole'

--- a/soa-gateway-service/build.gradle
+++ b/soa-gateway-service/build.gradle
@@ -83,6 +83,9 @@ wsimport {
 
 test {
     useJUnitPlatform()
+
+    // Hide warning for dynamic loading of agents https://github.com/mockito/mockito/issues/3037
+    jvmArgs '-XX:+EnableDynamicAgentLoading'
 }
 
 jacocoTestReport {

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/client/CoverSheetClient.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/client/CoverSheetClient.java
@@ -36,8 +36,8 @@ public class CoverSheetClient extends AbstractSoaClient {
    * @param serviceUrl         The URL endpoint for the cover sheet service.
    */
   public CoverSheetClient(WebServiceTemplate webServiceTemplate,
-      @Value("${laa.ccms.soa-gateway.document.service-name}") String serviceName,
-      @Value("${laa.ccms.soa-gateway.document.service-url}") String serviceUrl) {
+      @Value("${laa.ccms.soa-gateway.cover-sheet.service-name}") String serviceName,
+      @Value("${laa.ccms.soa-gateway.cover-sheet.service-url}") String serviceUrl) {
     this.webServiceTemplate = webServiceTemplate;
     this.serviceName = serviceName;
     this.serviceUrl = serviceUrl;

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/controller/DocumentController.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/controller/DocumentController.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.laa.ccms.soa.gateway.api.DocumentsApi;
-import uk.gov.laa.ccms.soa.gateway.model.BaseDocument;
 import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
 import uk.gov.laa.ccms.soa.gateway.model.CoverSheet;
 import uk.gov.laa.ccms.soa.gateway.model.Document;
@@ -29,7 +28,7 @@ public class DocumentController implements DocumentsApi {
    *
    * @param soaGatewayUserLoginId  (required) - the user requesting the data.
    * @param soaGatewayUserRole  (required) - the user role requesting the data.
-   * @param baseDocument  (required) - the base document details to register.
+   * @param document  (required) - the document details to register.
    * @param notificationReference  The ID of the notification to which this document
    *                               is related.
    * @return ResponseEntity wrapping the transaction id and registered document id.
@@ -38,14 +37,14 @@ public class DocumentController implements DocumentsApi {
   public ResponseEntity<ClientTransactionResponse> registerDocument(
           final String soaGatewayUserLoginId,
           final String soaGatewayUserRole,
-          final BaseDocument baseDocument,
+          final Document document,
           final String notificationReference) {
 
     try {
       ClientTransactionResponse response = documentService.registerDocument(
               soaGatewayUserLoginId,
               soaGatewayUserRole,
-              baseDocument,
+              document,
               notificationReference);
       return ResponseEntity.ok(response);
     } catch (Exception e) {

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/CommonMapper.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/CommonMapper.java
@@ -71,16 +71,36 @@ public interface CommonMapper {
         .orElse(null);
   }
 
+  /**
+   * Convert a y/n String to a boolean value.
+   *
+   * @param ynString the y/n string.
+   * @return true if the value is y/Y, false otherwise.
+   */
   default Boolean toBoolean(String ynString) {
     return ynString != null ? ynString.equalsIgnoreCase("Y") : null;
   }
 
+  /**
+   * Convert a boolean flag to a Y/N String.
+   *
+   * @param flag the boolean flag.
+   * @return "Y" if the boolean flag is true, otherwise "N".
+   */
   default String toYnString(Boolean flag) {
     return flag != null ? (flag ? "Y" : "N") : null;
   }
 
+  /**
+   * Convert a Base64 encoded string to an array of bytes.
+   *
+   * @param base64EncodedString the Base64 encoded string.
+   * @return the array of bytes, or null.
+   */
   default byte[] toByteArrayFromBase64EncodedString(String base64EncodedString) {
-    return Base64.getDecoder().decode(base64EncodedString);
+    return Optional.ofNullable(base64EncodedString)
+        .map(s -> Base64.getDecoder().decode(s))
+        .orElse(null);
   }
 
   /**

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/DocumentMapper.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/DocumentMapper.java
@@ -23,11 +23,14 @@ public interface DocumentMapper {
   DocumentUploadElementType toDocumentUploadElementType(final BaseDocument document);
 
   @Mapping(target = "CCMSDocumentID", source = "documentId")
-  @Mapping(target = "channel", constant = "E")
   @Mapping(target = ".", source = "document")
   @Mapping(target = "binData", source = "document.fileData")
   DocumentUploadElementType toDocumentUploadElementType(final String documentId,
       final Document document);
+
+  @Mapping(target = "CCMSDocumentID", ignore = true)
+  @Mapping(target = "binData", source = "document.fileData")
+  DocumentUploadElementType toDocumentUploadElementType(final Document document);
 
   @Mapping(target = "transactionId", source = "headerRS.transactionID")
   @Mapping(target = "referenceNumber", source = "documentID")

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/service/DocumentService.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/service/DocumentService.java
@@ -7,7 +7,6 @@ import uk.gov.laa.ccms.soa.gateway.client.CoverSheetClient;
 import uk.gov.laa.ccms.soa.gateway.client.DocumentClient;
 import uk.gov.laa.ccms.soa.gateway.mapper.CommonMapper;
 import uk.gov.laa.ccms.soa.gateway.mapper.DocumentMapper;
-import uk.gov.laa.ccms.soa.gateway.model.BaseDocument;
 import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
 import uk.gov.laa.ccms.soa.gateway.model.CoverSheet;
 import uk.gov.laa.ccms.soa.gateway.model.Document;
@@ -44,7 +43,7 @@ public class DocumentService extends AbstractSoaService {
   public ClientTransactionResponse registerDocument(
           final String soaGatewayUserLoginId,
           final String soaGatewayUserRole,
-          final BaseDocument document,
+          final Document document,
           final String notificationReference) {
 
     final DocumentUploadRS response = documentClient.registerDocument(

--- a/soa-gateway-service/src/main/resources/application-local.yml
+++ b/soa-gateway-service/src/main/resources/application-local.yml
@@ -36,3 +36,19 @@ laa:
               }
           ]'
           unprotected-uris: [ "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico", "/open-api-specification.yml" ]
+
+# Log SOAP requests
+#logging:
+#  level:
+#    org:
+#      springframework:
+#        web: DEBUG
+#        ws:
+#          client:
+#            MessageTracing:
+#              sent: DEBUG
+#              received: TRACE
+#          server:
+#            MessageTracing:
+#              sent: DEBUG
+#              received: TRACE

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/controller/DocumentControllerTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/controller/DocumentControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import uk.gov.laa.ccms.soa.gateway.model.BaseDocument;
 import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
 import uk.gov.laa.ccms.soa.gateway.model.CoverSheet;
 import uk.gov.laa.ccms.soa.gateway.model.Document;
@@ -46,23 +45,23 @@ class DocumentControllerTest {
     public void testRegisterDocument_Success() throws Exception {
         final String soaGatewayUserLoginId = "user";
         final String soaGatewayUserRole = "EXTERNAL";
-        BaseDocument baseDocument = new BaseDocument();
+        Document document = new Document();
         ClientTransactionResponse clientTransactionResponse = new ClientTransactionResponse()
             .transactionId("trans123")
             .referenceNumber("doc123");
 
-        when(documentService.registerDocument(soaGatewayUserLoginId, soaGatewayUserRole, baseDocument, null))
+        when(documentService.registerDocument(soaGatewayUserLoginId, soaGatewayUserRole, document, null))
             .thenReturn(clientTransactionResponse);
 
         mockMvc.perform(
                 post("/documents")
-                    .content(new ObjectMapper().writeValueAsString(baseDocument))
+                    .content(new ObjectMapper().writeValueAsString(document))
                     .contentType(MediaType.APPLICATION_JSON)
                     .header("SoaGateway-User-Login-Id", soaGatewayUserLoginId)
                     .header("SoaGateway-User-Role", soaGatewayUserRole))
             .andExpect(status().isOk());
 
-        verify(documentService).registerDocument(soaGatewayUserLoginId, soaGatewayUserRole, baseDocument, null);
+        verify(documentService).registerDocument(soaGatewayUserLoginId, soaGatewayUserRole, document, null);
     }
 
     @Test

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/CommonMapperTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/CommonMapperTest.java
@@ -236,6 +236,16 @@ public class CommonMapperTest {
         assertEquals(opaAttributesType.getResponseValue(), opaAttribute.getResponseValue());
     }
 
+    @Test
+    public void testToByteArrayFromBase64EncodedString_handlesNullValue() {
+        assertNull(commonMapper.toByteArrayFromBase64EncodedString(null));
+    }
+
+    @Test
+    public void testToBase64EncodedStringFromByteArray_handlesNullValue() {
+        assertNull(commonMapper.toBase64EncodedStringFromByteArray(null));
+    }
+
     @ParameterizedTest
     @CsvSource(value = {
         "Y, true",

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/DocumentMapperTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/DocumentMapperTest.java
@@ -2,6 +2,7 @@ package uk.gov.laa.ccms.soa.gateway.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,7 @@ public class DocumentMapperTest {
         document.setDocumentType("docType");
         document.setFileExtension("fileExt");
         document.setText("thetext");
+        document.setChannel("E");
 
         DocumentUploadElementType result =
             documentMapper.toDocumentUploadElementType(documentId, document);
@@ -60,6 +62,30 @@ public class DocumentMapperTest {
         assertNotNull(result);
         assertEquals(document.getFileData(), Base64.getEncoder().encodeToString(result.getBinData()));
         assertEquals(documentId, result.getCCMSDocumentID());
+        assertEquals("E", result.getChannel());
+        assertEquals(document.getDocumentLink(), result.getDocumentLink());
+        assertEquals(document.getDocumentType(), result.getDocumentType());
+        assertEquals(document.getFileExtension(), result.getFileExtension());
+        assertEquals(document.getText(), result.getText());
+    }
+
+    @Test
+    public void testToDocumentUploadElementType_noId() {
+        // Create a mocked instance of soa response object
+        Document document = new Document();
+        document.setFileData("dGhlIGZpbGUgZGF0YQ==");
+        document.setDocumentId("docId");
+        document.setDocumentType("docType");
+        document.setFileExtension("fileExt");
+        document.setText("thetext");
+        document.setChannel("E");
+
+        DocumentUploadElementType result =
+            documentMapper.toDocumentUploadElementType(document);
+
+        assertNotNull(result);
+        assertNull(result.getCCMSDocumentID());
+        assertEquals(document.getFileData(), Base64.getEncoder().encodeToString(result.getBinData()));
         assertEquals("E", result.getChannel());
         assertEquals(document.getDocumentLink(), result.getDocumentLink());
         assertEquals(document.getDocumentType(), result.getDocumentType());

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/service/DocumentServiceTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/service/DocumentServiceTest.java
@@ -14,7 +14,6 @@ import uk.gov.laa.ccms.soa.gateway.client.CoverSheetClient;
 import uk.gov.laa.ccms.soa.gateway.client.DocumentClient;
 import uk.gov.laa.ccms.soa.gateway.mapper.CommonMapper;
 import uk.gov.laa.ccms.soa.gateway.mapper.DocumentMapper;
-import uk.gov.laa.ccms.soa.gateway.model.BaseDocument;
 import uk.gov.laa.ccms.soa.gateway.model.ClientTransactionResponse;
 import uk.gov.laa.ccms.soa.gateway.model.CoverSheet;
 import uk.gov.laa.ccms.soa.gateway.model.Document;
@@ -44,12 +43,12 @@ public class DocumentServiceTest {
     public void testRegisterDocument() {
         String soaGatewayUserLoginId = "soaGatewayUserLoginId";
         String soaGatewayUserRole = "soaGatewayUserRole";
-        BaseDocument baseDocument = new BaseDocument();
+        Document document = new Document();
         DocumentUploadElementType documentUploadElementType = new DocumentUploadElementType();
         DocumentUploadRS documentUploadRS = new DocumentUploadRS();
         ClientTransactionResponse clientTransactionResponse = new ClientTransactionResponse();
 
-        when(documentMapper.toDocumentUploadElementType(baseDocument))
+        when(documentMapper.toDocumentUploadElementType(document))
             .thenReturn(documentUploadElementType);
 
         // Stub the Client to return the mocked response
@@ -65,7 +64,7 @@ public class DocumentServiceTest {
         ClientTransactionResponse result = documentService.registerDocument(
             soaGatewayUserLoginId,
             soaGatewayUserRole,
-            baseDocument,
+            document,
             null);
 
         // Verify that the NotificationClient method was called with the expected arguments

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/service/OrganisationServiceTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/service/OrganisationServiceTest.java
@@ -51,6 +51,7 @@ public class OrganisationServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testGetOrganisations() {
         OrganisationSummary searchOrganisation = new OrganisationSummary();
         Organization organization = buildOrganization();


### PR DESCRIPTION
* `POST /documents` now takes in a `Document` object rather than `BaseDocument` to allow file data and other fields to be uploaded in one go, rather than register + upload. 

Also:

* Fixed bug with GetCoverSheet client which was pointing to the wrong service URL
* Cleared up build warnings - agent loading + unchecked assignment