### PR TITLE
Story(ccmspui-4) amend currently trading string to boolean

### DIFF
--- a/soa-gateway-api/open-api-specification.yml
+++ b/soa-gateway-api/open-api-specification.yml
@@ -1368,7 +1368,7 @@ components:
         organization_type:
           type: 'string'
         currently_trading:
-          type: 'string'
+          type: 'boolean'
         relation_To_client:
           type: 'string'
         relation_to_case:

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapper.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapper.java
@@ -26,6 +26,7 @@ import uk.gov.laa.ccms.soa.gateway.model.OpaAttribute;
 import uk.gov.laa.ccms.soa.gateway.model.OpaGoal;
 import uk.gov.laa.ccms.soa.gateway.model.OtherAsset;
 import uk.gov.laa.ccms.soa.gateway.model.OtherParty;
+import uk.gov.laa.ccms.soa.gateway.model.OtherPartyOrganisation;
 import uk.gov.laa.ccms.soa.gateway.model.OtherPartyPerson;
 import uk.gov.laa.ccms.soa.gateway.model.OutcomeDetail;
 import uk.gov.laa.ccms.soa.gateway.model.PriorAuthority;
@@ -58,6 +59,7 @@ import uk.gov.legalservices.ccms.casemanagement._case._1_0.casebio.LinkedCaseUpd
 import uk.gov.legalservices.ccms.casemanagement._case._1_0.casebio.LinkedCasesUpdate;
 import uk.gov.legalservices.ccms.casemanagement._case._1_0.casebio.OtherAssetElementType;
 import uk.gov.legalservices.ccms.casemanagement._case._1_0.casebio.OtherPartyElementType;
+import uk.gov.legalservices.ccms.casemanagement._case._1_0.casebio.OtherPartyOrgType;
 import uk.gov.legalservices.ccms.casemanagement._case._1_0.casebio.OtherPartyPersonType;
 import uk.gov.legalservices.ccms.casemanagement._case._1_0.casebio.OutcomeDetailElementType;
 import uk.gov.legalservices.ccms.casemanagement._case._1_0.casebio.PriorAuthorities;
@@ -364,7 +366,13 @@ public interface CaseDetailsMapper {
   OtherParty toOtherParty(final OtherPartyElementType otherPartyElementType);
 
   @InheritInverseConfiguration
+  @Mapping(target = "otherPartyDetail.organization", source = "organisation")
   OtherPartyElementType toOtherPartyElementType(final OtherParty otherParty);
+
+  OtherPartyOrganisation toOtherPartyOrganisation(final OtherPartyOrgType otherPartyOrgType);
+
+  @InheritInverseConfiguration
+  OtherPartyOrgType toOtherPartyOrgType(final OtherPartyOrganisation otherPartyOrganisation);
 
   @Mapping(target = "contactUserId", source = "contactUserID")
   @Mapping(target = "providerFirmId", source = "providerFirmID")

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapperTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.laa.ccms.soa.gateway.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -372,6 +373,7 @@ public class CaseDetailsMapperTest {
     OtherPartyOrgType otherPartyOrgType = otherPartyElementType.getOtherPartyDetail()
         .getOrganization();
     OtherPartyOrganisation otherPartyOrganisation = result.getOrganisation();
+
     compareContactDetails(otherPartyOrgType.getContactDetails(),
         otherPartyOrganisation.getContactDetails());
     assertEquals(otherPartyOrgType.getOtherInformation(),
@@ -381,8 +383,7 @@ public class CaseDetailsMapperTest {
         otherPartyOrganisation.getOrganizationType());
     assertEquals(otherPartyOrgType.getContactName(),
         otherPartyOrganisation.getContactName());
-    assertEquals(otherPartyOrgType.getCurrentlyTrading(),
-        otherPartyOrganisation.getCurrentlyTrading());
+    assertFalse(otherPartyOrganisation.isCurrentlyTrading());
     assertEquals(otherPartyOrgType.getRelationToClient(),
         otherPartyOrganisation.getRelationToClient());
     assertNotNull(otherPartyOrganisation.getAddress());
@@ -1076,7 +1077,7 @@ public class CaseDetailsMapperTest {
             .address(new AddressDetail()) // common mapper
             .contactDetails(new ContactDetail()) // tested elsewhere
             .contactName("orgconname")
-            .currentlyTrading("curTrad")
+            .currentlyTrading(false)
             .organizationName("orgname")
             .organizationType("orgtype")
             .otherInformation("orgotherinf")
@@ -1103,7 +1104,6 @@ public class CaseDetailsMapperTest {
     assertNotNull(resultOrg.getAddress());
     assertNotNull(resultOrg.getContactDetails());
     assertEquals(otherParty.getOrganisation().getContactName(), resultOrg.getContactName());
-    assertEquals(otherParty.getOrganisation().getCurrentlyTrading(), resultOrg.getCurrentlyTrading());
     assertEquals(otherParty.getOrganisation().getOrganizationName(), resultOrg.getOrganizationName());
     assertEquals(otherParty.getOrganisation().getOrganizationType(), resultOrg.getOrganizationType());
     assertEquals(otherParty.getOrganisation().getOtherInformation(), resultOrg.getOtherInformation());

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/util/SoaModelUtils.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/util/SoaModelUtils.java
@@ -665,7 +665,7 @@ public class SoaModelUtils {
     otherPartyOrgType.setContactDetails(buildContactDetails());
     otherPartyOrgType.setOrganizationType("orgtype");
     otherPartyOrgType.setContactName("name");
-    otherPartyOrgType.setCurrentlyTrading("trading");
+    otherPartyOrgType.setCurrentlyTrading("N");
     otherPartyOrgType.setOrganizationName("name");
     otherPartyOrgType.setRelationToCase("relation");
     otherPartyOrgType.setRelationToClient("toclient");


### PR DESCRIPTION
Required as part of finalise and submit application
SOA requires currently trading as "Y" the api was taking in a string value "true" and the YN converter we have wasn't being utilised. Amended the spec to adjust the input to a boolean, now converter is utilised. 