### PR TITLE
story(ccmspui-313) add case reference to document upload endpoint

### DIFF
--- a/soa-gateway-api/open-api-specification.yml
+++ b/soa-gateway-api/open-api-specification.yml
@@ -646,6 +646,11 @@ paths:
           schema:
             type: 'string'
             example: '1234567890'
+        - name: 'case-reference-number'
+          in: 'query'
+          schema:
+            type: 'string'
+            example: '1234567890'
       responses:
         '200':
           description: 'Successful operation'

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/controller/DocumentController.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/controller/DocumentController.java
@@ -31,6 +31,8 @@ public class DocumentController implements DocumentsApi {
    * @param document  (required) - the document details to register.
    * @param notificationReference  The ID of the notification to which this document
    *                               is related.
+   * @param caseReferenceNumber    The reference id of the case to which this document
+   *                               is related.
    * @return ResponseEntity wrapping the transaction id and registered document id.
    */
   @Override
@@ -38,14 +40,16 @@ public class DocumentController implements DocumentsApi {
           final String soaGatewayUserLoginId,
           final String soaGatewayUserRole,
           final Document document,
-          final String notificationReference) {
+          final String notificationReference,
+          final String caseReferenceNumber) {
 
     try {
       final ClientTransactionResponse response = documentService.registerDocument(
               soaGatewayUserLoginId,
               soaGatewayUserRole,
               document,
-              notificationReference);
+              notificationReference,
+              caseReferenceNumber);
       return ResponseEntity.ok(response);
     } catch (Exception e) {
       log.error("DocumentController caught exception", e);

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/ProviderRequestsMapper.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/ProviderRequestsMapper.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
-import org.mapstruct.factory.Mappers;
 import uk.gov.laa.ccms.soa.gateway.mapper.context.ProviderRequestMappingContext;
 import uk.gov.laa.ccms.soa.gateway.model.ProviderRequestAttribute;
 import uk.gov.laa.ccms.soa.gateway.model.ProviderRequestDetail;

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/service/DocumentService.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/service/DocumentService.java
@@ -37,6 +37,8 @@ public class DocumentService extends AbstractSoaService {
    * @param document               The document details to register
    * @param notificationReference  The ID of the notification to which this document
    *                               is related.
+   * @param caseReferenceNumber    The reference id of the case to which this document
+   *                               is related.
    * @return                       A {@link ClientTransactionResponse} object containing the
    *                               transaction id and ebs registered document id.
    */
@@ -44,14 +46,15 @@ public class DocumentService extends AbstractSoaService {
           final String soaGatewayUserLoginId,
           final String soaGatewayUserRole,
           final Document document,
-          final String notificationReference) {
+          final String notificationReference,
+          final String caseReferenceNumber) {
 
     final DocumentUploadRS response = documentClient.registerDocument(
         soaGatewayUserLoginId,
         soaGatewayUserRole,
         documentMapper.toDocumentUploadElementType(document),
         notificationReference,
-        null);
+        caseReferenceNumber);
 
     return documentMapper.toClientTransactionResponse(response);
   }

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/controller/DocumentControllerTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/controller/DocumentControllerTest.java
@@ -52,7 +52,7 @@ class DocumentControllerTest {
             .transactionId("trans123")
             .referenceNumber("doc123");
 
-        when(documentService.registerDocument(soaGatewayUserLoginId, soaGatewayUserRole, document, null))
+        when(documentService.registerDocument(soaGatewayUserLoginId, soaGatewayUserRole, document, null, null))
             .thenReturn(clientTransactionResponse);
 
         mockMvc.perform(
@@ -63,7 +63,7 @@ class DocumentControllerTest {
                     .header("SoaGateway-User-Role", soaGatewayUserRole))
             .andExpect(status().isOk());
 
-        verify(documentService).registerDocument(soaGatewayUserLoginId, soaGatewayUserRole, document, null);
+        verify(documentService).registerDocument(soaGatewayUserLoginId, soaGatewayUserRole, document, null, null);
     }
 
     @ParameterizedTest

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/service/DocumentServiceTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/service/DocumentServiceTest.java
@@ -68,7 +68,7 @@ public class DocumentServiceTest {
             soaGatewayUserLoginId,
             soaGatewayUserRole,
             document,
-            null);
+            null, null);
 
         // Verify that the NotificationClient method was called with the expected arguments
         verify(documentClient).registerDocument(


### PR DESCRIPTION
As part of the general requests epic and while doing the ui work it was discovered that the document upload endpoint required changing so that case reference number could be specified.