### PR TITLE
Fix: [CCMSPUI 450] Remove Sarif Report Uploads

### DIFF
--- a/.github/workflows/pr-merge-main.yml
+++ b/.github/workflows/pr-merge-main.yml
@@ -83,4 +83,4 @@ jobs:
         continue-on-error: true
         with:
           command: monitor
-          args: --org=${SNYK_ORG} --all-projects --exclude=$SNYK_TEST_EXCLUDE
+          args: --org=$SNYK_ORG --all-projects --exclude=$SNYK_TEST_EXCLUDE


### PR DESCRIPTION
GitHub Advanced Security is disabled for private repositories, so the workflows in this repository don't have access to publish reports to GitHub Security Scanning.