### PR TITLE
fix(CCMSPUI-695): Fix CaseDetailsMapper to accommodate Undertaking Fields

### DIFF
--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapper.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapper.java
@@ -141,6 +141,7 @@ public interface CaseDetailsMapper {
       target = "meritsAssesments.assesmentResults",
       source = "applicationDetails.meritsAssessments")
   @Mapping(target = ".", source = "applicationDetails")
+  @Mapping(target = "undertakings", source = "caseDetail")
   @Mapping(
       target = "applicationAmendmentType",
       source = ".",

--- a/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapper.java
+++ b/soa-gateway-service/src/main/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapper.java
@@ -116,7 +116,7 @@ public interface CaseDetailsMapper {
   @Mapping(target = "headerRQ", ignore = true)
   @Mapping(target = "actualCaseStatus", ignore = true)
   @Mapping(target = "messages", ignore = true)
-  @Mapping(target = "undertakings", ignore = true)
+  @Mapping(target = "undertakings", source = "caseDetail")
   CaseUpdateRQ toCaseUpdateRq(final CaseDetail caseDetail, @Context String caseUpdateType);
 
   @Mapping(target = "proceedingCaseID", source = "proceedingCaseId")
@@ -141,7 +141,6 @@ public interface CaseDetailsMapper {
       target = "meritsAssesments.assesmentResults",
       source = "applicationDetails.meritsAssessments")
   @Mapping(target = ".", source = "applicationDetails")
-  @Mapping(target = "undertakings", source = "caseDetail")
   @Mapping(
       target = "applicationAmendmentType",
       source = ".",

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapperTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapperTest.java
@@ -1848,7 +1848,6 @@ public class CaseDetailsMapperTest {
     caseUpdateRQ.setAwards(awardsElementType);
     caseUpdateRQ.setPriorAuthorities(priorAuthorities);
     caseUpdateRQ.setDischargeStatus(null);
-    caseUpdateRQ.setUndertakings(null);
     caseUpdateRQ.setOutcomes(outcomes);
     caseUpdateRQ.setRecordHistory(recordHistory);
     caseUpdateRQ.setCaseDocs(caseDocs);

--- a/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapperTest.java
+++ b/soa-gateway-service/src/test/java/uk/gov/laa/ccms/soa/gateway/mapper/CaseDetailsMapperTest.java
@@ -1833,6 +1833,8 @@ public class CaseDetailsMapperTest {
 
     CaseDocs caseDocs = buildExpectedCaseDocs();
 
+    UndertakingElementType undertakingElementType = buildExpectedUndertakingElementType();
+
     CaseUpdateRQ caseUpdateRQ = new CaseUpdateRQ();
     caseUpdateRQ.setCaseReferenceNumber("caseReferenceNumber");
     caseUpdateRQ.setUpdateMsgType(caseUpdateType);
@@ -1850,6 +1852,7 @@ public class CaseDetailsMapperTest {
     caseUpdateRQ.setOutcomes(outcomes);
     caseUpdateRQ.setRecordHistory(recordHistory);
     caseUpdateRQ.setCaseDocs(caseDocs);
+    caseUpdateRQ.setUndertakings(undertakingElementType);
 
     return caseUpdateRQ;
   }


### PR DESCRIPTION
This pull request updates how the `undertakings` field is mapped and tested in the case update functionality. The main change is that the `undertakings` property in `CaseUpdateRQ` is now mapped from the source `caseDetail` object, rather than being ignored, and the relevant test has been updated to reflect this change.

**Mapping logic changes:**

* The `CaseDetailsMapper` interface now maps the `undertakings` field from the `caseDetail` source instead of ignoring it, ensuring that undertakings data is included in the mapping to `CaseUpdateRQ`.

**Test updates:**

* The test helper method `buildExpectedCaseUpdateRq` in `CaseDetailsMapperTest.java` now creates and sets an `UndertakingElementType` for the `undertakings` field in the expected `CaseUpdateRQ`, aligning the test with the updated mapping logic. 